### PR TITLE
Update parsing to look for article instead of div

### DIFF
--- a/cookie.py
+++ b/cookie.py
@@ -155,7 +155,7 @@ class CookieHandler(handlers.ModernHandler):
     else:
       logging.warning("Couldn't determine username or id!")
 
-    posts = soup.find_all('div', id=re.compile('u_0_.'))
+    posts = soup.find_all('article', id=re.compile('u_0_.'))
     logging.info('Found %d posts', len(posts))
 
     entries = []


### PR DESCRIPTION
It seems that Facebook has changed the source code of the News Feed around the 15th of April.
I've noticed that my feed stopped updating around that date.

Looking into the source code confirmed that posts are now wrapped into the `<article id="u_0_*">` instead of `<div ...>`.
I updated the parsing code and validated that it works locally.